### PR TITLE
Add a birthday-generating model

### DIFF
--- a/src/cic/io/read.clj
+++ b/src/cic/io/read.clj
@@ -185,3 +185,13 @@
    :phase-duration-quantiles (phase-duration-quantiles-csv phase-duration-quantiles)
    :phase-bernoulli-params (age-beta-params phase-bernoulli-params)
    :phase-beta-params (age-beta-params phase-beta-params)})
+
+(defn zero-joiner-day-ages
+  [filename]
+  (->> (load-csv filename)
+       (map (fn [row]
+              (-> row
+                  (update :n parse-int)
+                  (update :x parse-int))))
+       (sort-by :n)
+       (mapv :x)))

--- a/src/cic/model.clj
+++ b/src/cic/model.clj
@@ -214,7 +214,12 @@
                   (recur next-offset next-placement (conj placements {:offset next-offset :placement next-placement})))))))))))
 
 (defn joiner-birthday-model
-  "Accepts quantiles for age zero joiner ages in days and returns a birthday-generating model"
+  "Accepts quantiles for age zero joiner ages in days and returns a birthday-generating model
+  FIXME: Create a DSDR documenting the fact that age zero joiners have been observed to join
+  soon after birth. This means that age zero joiners tend disproportionately to be only days
+  old when joining. Without adjusting for this we will generate too many older joiners
+  which will manifest itself as an increase in age 1 year CiC, and so on. Those children
+  previously would have left the system before their first birthday."
   [quantiles]
   (let [q (vec quantiles)
         n (count quantiles)

--- a/src/cic/model.clj
+++ b/src/cic/model.clj
@@ -212,3 +212,16 @@
                 placements
                 (let [next-placement (phase-transition (zero? offset) age placement)]
                   (recur next-offset next-placement (conj placements {:offset next-offset :placement next-placement})))))))))))
+
+(defn joiner-birthday-model
+  "Accepts quantiles for age zero joiner ages in days and returns a birthday-generating model"
+  [quantiles]
+  (let [q (vec quantiles)
+        n (count quantiles)
+        dist (d/uniform {:a 0 :b n})]
+    (fn [age join-date seed]
+      (if (zero? age)
+        (let [i (int (p/sample-1 dist seed))]
+          (time/days-before join-date (get q i)))
+        (-> (time/days-before join-date (int (p/sample-1 (d/uniform {:a 0 :b 366}) seed)))
+            (time/years-before age))))))

--- a/src/cic/projection.clj
+++ b/src/cic/projection.clj
@@ -22,14 +22,13 @@
 
 (defn joiners-seq
   "Return a lazy sequence of projected joiners for a particular age of admission."
-  [joiners-model duration-model placements-model age beginning previous-offset end seed]
+  [joiners-model duration-model placements-model joiner-birthday-model age beginning previous-offset end seed]
   (let [[seed-1 seed-2 seed-3 seed-4 seed-5 seed-6] (rand/split-n seed 6)
         interval (joiners-model beginning seed-1)
         new-offset (+ previous-offset interval)
         next-time (time/days-after beginning new-offset)
         start-time (time/without-time next-time)
-        birthday (-> (time/days-before start-time (p/sample-1 (d/uniform {:a 0 :b 364}) seed-6))
-                     (time/years-before age))
+        birthday (joiner-birthday-model start-time seed-6)
         duration (duration-model birthday start-time seed-2)
         episodes (placements-model duration {:beginning start-time :birthday birthday
                                              :duration 0 :episodes []} seed-3)]
@@ -44,21 +43,23 @@
                     :episodes episodes}]
         (cons period
               (lazy-seq
-               (joiners-seq joiners-model duration-model placements-model age beginning new-offset end seed-5)))))))
+               (joiners-seq joiners-model duration-model placements-model joiner-birthday-model age beginning new-offset end seed-5)))))))
 
 (defn project-joiners
   "Return a lazy sequence of projected joiners for all ages of admission."
-  [{:keys [joiners-model duration-model episodes-model placements-model] :as model} beginning end seed]
+  [{:keys [joiners-model duration-model episodes-model placements-model joiner-birthday-model] :as model} beginning end seed]
   (mapcat (fn [age seed]
             (joiners-seq (partial joiners-model age)
                          duration-model
-                         (partial placements-model age) age beginning 0 end seed))
+                         (partial placements-model age)
+                         (partial joiner-birthday-model age)
+                         age beginning 0 end seed))
           spec/ages
           (rand/split-n seed (count spec/ages))))
 
 (defn train-model
   "Build stochastic helper models using R. Random seed ensures determinism."
-  [{:keys [seed joiner-range episodes-range duration-model placements-model project-to] :as model-seed} random-seed]
+  [{:keys [seed joiner-range episodes-range duration-model placements-model joiner-birthday-model project-to] :as model-seed} random-seed]
   (let [[s1 s2] (rand/split-n random-seed 2)
         [joiners-from joiners-to] joiner-range
         [episodes-from episodes-to] episodes-range
@@ -68,6 +69,7 @@
                         (model/joiners-model-gen project-to s2))
      :episodes-model (-> (filter #(time/between? (:end %) episodes-from episodes-to) closed-periods)
                          (model/episodes-model))
+     :joiner-birthday-model joiner-birthday-model
      :duration-model duration-model
      :placements-model placements-model}))
 


### PR DESCRIPTION
Adjust the allocation of birthdays to account for the fact that up to half of all age zero joiners will join in the month of their birth