### PR TITLE
Per age joiner base date

### DIFF
--- a/src/cic/projection.clj
+++ b/src/cic/projection.clj
@@ -9,7 +9,7 @@
 
 (defn project-period-close
   "Sample a possible duration in care which is greater than the existing duration"
-  [{:keys [duration-model episodes-model placements-model] :as model}
+  [{:keys [duration-model placements-model] :as model}
    {:keys [duration birthday beginning admission-age episodes period-id open?] :as period} seed]
   (if open?
     (let [projected-duration (duration-model birthday beginning duration seed)
@@ -47,7 +47,7 @@
 
 (defn project-joiners
   "Return a lazy sequence of projected joiners for all ages of admission."
-  [{:keys [joiners-model duration-model episodes-model placements-model joiner-birthday-model] :as model}
+  [{:keys [joiners-model duration-model placements-model joiner-birthday-model] :as model}
    projection-seed end seed]
   (let [previous-joiner-per-age (->> (group-by :admission-age (:seed projection-seed))
                                      (reduce (fn [m [k v]] (assoc m k (time/max-date (map :beginning v)))) {}))]
@@ -72,8 +72,6 @@
         closed-periods (filter :end periods)]
     {:joiners-model (-> (filter #(time/between? (:beginning %) joiners-from joiners-to) periods)
                         (model/joiners-model-gen project-to s2))
-     :episodes-model (-> (filter #(time/between? (:end %) episodes-from episodes-to) closed-periods)
-                         (model/episodes-model))
      :placements-model (model/periods->placements-model periods)
      :phase-durations phase-durations
      :joiner-birthday-model joiner-birthday-model

--- a/src/cic/projection.clj
+++ b/src/cic/projection.clj
@@ -22,20 +22,20 @@
 
 (defn joiners-seq
   "Return a lazy sequence of projected joiners for a particular age of admission."
-  [joiners-model duration-model placements-model joiner-birthday-model age beginning previous-offset end seed]
+  [joiners-model duration-model placements-model joiner-birthday-model last-joiner previous-offset age end seed]
   (let [[seed-1 seed-2 seed-3 seed-4 seed-5 seed-6] (rand/split-n seed 6)
-        interval (joiners-model beginning seed-1)
+        interval (joiners-model (time/days-after last-joiner previous-offset) seed-1)
         new-offset (+ previous-offset interval)
-        next-time (time/days-after beginning new-offset)
+        next-time (time/days-after last-joiner new-offset)
         start-time (time/without-time next-time)
         birthday (joiner-birthday-model start-time seed-6)
         duration (duration-model birthday start-time seed-2)
         episodes (placements-model duration {:beginning start-time :birthday birthday
                                              :duration 0 :episodes []} seed-3)]
     (when (time/< next-time end)
-      (let [period-end (time/days-after next-time duration)
+      (let [period-end (time/without-time (time/days-after start-time duration))
             period {:beginning start-time
-                    :end (time/without-time period-end)
+                    :end period-end
                     :period-id (rand/rand-id 8 seed-4)
                     :birthday birthday
                     :admission-age age
@@ -43,19 +43,24 @@
                     :episodes episodes}]
         (cons period
               (lazy-seq
-               (joiners-seq joiners-model duration-model placements-model joiner-birthday-model age beginning new-offset end seed-5)))))))
+               (joiners-seq joiners-model duration-model placements-model joiner-birthday-model last-joiner new-offset age end seed-5)))))))
 
 (defn project-joiners
   "Return a lazy sequence of projected joiners for all ages of admission."
-  [{:keys [joiners-model duration-model episodes-model placements-model joiner-birthday-model] :as model} beginning end seed]
-  (mapcat (fn [age seed]
-            (joiners-seq (partial joiners-model age)
-                         duration-model
-                         (partial placements-model age)
-                         (partial joiner-birthday-model age)
-                         age beginning 0 end seed))
-          spec/ages
-          (rand/split-n seed (count spec/ages))))
+  [{:keys [joiners-model duration-model episodes-model placements-model joiner-birthday-model] :as model}
+   projection-seed end seed]
+  (let [previous-joiner-per-age (->> (group-by :admission-age (:seed projection-seed))
+                                     (reduce (fn [m [k v]] (assoc m k (time/max-date (map :beginning v)))) {}))]
+    (mapcat (fn [age seed]
+              (let [previous-joiner-at-age (get previous-joiner-per-age age (:date projection-seed))]
+                (joiners-seq (partial joiners-model age (:date projection-seed))
+                             duration-model
+                             (partial placements-model age)
+                             (partial joiner-birthday-model age)
+                             previous-joiner-at-age 0
+                             age end seed)))
+            spec/ages
+            (rand/split-n seed (count spec/ages)))))
 
 (defn train-model
   "Build stochastic helper models using R. Random seed ensures determinism."
@@ -82,7 +87,7 @@
         model (train-model model-seed s1)
         projection-seed (update projection-seed :seed rand/sample-birthdays s4)]
     (-> (map (partial project-period-close model) (:seed projection-seed) (rand/split-n s2 (count (:seed projection-seed))))
-        (concat (project-joiners model (:date projection-seed) end s3)))))
+        (concat (project-joiners model projection-seed end s3)))))
 
 (defn project-n
   "Returns n stochastic sequences of projected periods."

--- a/src/cic/repl.clj
+++ b/src/cic/repl.clj
@@ -65,9 +65,10 @@
 (defn generate-projection-csv!
   "Main REPL function for writing a projection CSV"
   [rewind-years train-years project-years n-runs seed]
-  (let [output-file (output-file (format "%syr-rewind-%syr-train-%syr-project-%s-runs-%s-seed-testing.csv" rewind-years train-years project-years n-runs seed))
+  (let [output-file (output-file (format "projection-rewind-%syr-train-%syr-project-%syr-runs-%s-seed-%s.csv" rewind-years train-years project-years n-runs seed))
         {:keys [project-from periods placement-costs duration-model joiner-birthday-model]} (prepare-model-inputs (load-model-inputs))
-        project-from (time/years-before project-from rewind-years)
+        project-from (time/quarter-preceding (time/years-before project-from rewind-years))
+        _ (println (str "Project from " project-from))
         project-to (time/years-after project-from project-years)
         learn-from (time/years-before project-from train-years)
         projection-periods (periods/periods-as-at periods project-from)
@@ -180,10 +181,14 @@
 
 (defn generate-validation-csv!
   "Outputs model projection and linear regression projection together with actuals for comparison."
-  [output-file train-years n-runs seed]
-  (let [{:keys [periods placement-costs duration-model joiner-birthday-model]} (prepare-model-inputs (load-model-inputs))
-        project-from (time/years-before (time/max-date (map :beginning periods)) 1)
-        project-to (time/years-after project-from 1)
+  [train-years n-runs seed]
+  (let [rewind-years 1
+        project-years 1
+        output-file (output-file (format "validation-rewind-%syr-train-%syr-project-%syr-runs-%s-seed-%s.csv" rewind-years train-years project-years n-runs seed))
+        {:keys [project-from periods placement-costs duration-model joiner-birthday-model]} (prepare-model-inputs (load-model-inputs))
+        project-from (time/quarter-preceding (time/years-before project-from rewind-years))
+        _ (println (str "Project from " project-from))
+        project-to (time/years-after project-from project-years)
         learn-from (time/years-before project-from train-years)
         projection-periods (periods/periods-as-at periods project-from)
         projection-seed {:seed (filter :open? projection-periods)
@@ -210,12 +215,13 @@
 (defn generate-episodes-csv!
   "Outputs a file showing a single projection in rowise episodes format."
   [rewind-years train-years project-years n-runs seed]
-  (let [output-file (output-file (format "episodes-%syr-rewind-%syr-train-%syr-project-%s-runs-%s-seed-testing.csv" rewind-years train-years project-years n-runs seed))
+  (let [output-file (output-file (format "episodes-rewind-%syr-train-%syr-project-%syr-runs-%s-seed-%s.csv" rewind-years train-years project-years n-runs seed))
+        _ (println output-file)
         {:keys [project-from periods placement-costs duration-model joiner-birthday-model] :as model-inputs} (prepare-model-inputs (load-model-inputs))
-        project-from (time/years-before project-from rewind-years)
+        project-from (time/quarter-preceding (time/years-before project-from rewind-years))
         _ (println (str "Project from " project-from))
         project-to (time/years-after project-from project-years)
-        learn-from (time/quarter-following (time/years-before project-from train-years))
+        learn-from (time/years-before project-from train-years)
         periods (periods/periods-as-at periods project-from)
         projection-seed {:seed periods
                          :date project-from}

--- a/src/cic/time.clj
+++ b/src/cic/time.clj
@@ -113,6 +113,10 @@
         year (if (== quarter 1) (inc (t/year test)) (t/year test))]
     (t/date-time year quarter)))
 
+(defn quarter-preceding
+  [date]
+  (t/minus (quarter-following (t/plus date (t/days 1))) (t/months 3)))
+
 (defn financial-year-end
   [date]
   (let [year-end (t/date-time (t/year date) 3 31)]


### PR DESCRIPTION
Ensure correct joiner intervals by starting the clock at the time of the last joiner at each respective age.