### PR TITLE
Output projection periods as EDN

### DIFF
--- a/data/demo/config.edn
+++ b/data/demo/config.edn
@@ -26,6 +26,7 @@
 
  :output-parameters {:output-historic-episodes? true
                      :output-projection-episodes? true
+                     :output-projection-periods? true
                      :output-projection-summary? false
                      :output-file-inputs? false
                      }

--- a/src/cic/io/write.clj
+++ b/src/cic/io/write.clj
@@ -279,3 +279,9 @@
     (into []
           (map fields)
           joiner-intervals)))
+
+(defn write-edn!
+  [out-file data]
+  (with-open [writer (io/writer out-file)]
+    (binding [*out* writer]
+      (pr data))))

--- a/src/cic/repl.clj
+++ b/src/cic/repl.clj
@@ -120,6 +120,7 @@
         ;; Output files
         projection-summary-output (fs/file output-directory "projection-summary.csv")
         projection-episodes-output (fs/file output-directory "projection-episodes.csv")
+        projection-periods-output (fs/file output-directory "projection-periods.edn")
         historic-episodes-output (fs/file output-directory "historic-episodes.csv")
         ;; Log files
         joiner-rates-log-output (fs/file log-directory "joiner-rates-log.csv")
@@ -154,7 +155,9 @@
                       (:output-projection-summary? output-parameters)
                       (conj :projection-summary)
                       (:output-projection-episodes? output-parameters)
-                      (conj :projection-episodes))]
+                      (conj :projection-episodes)
+                      (:output-projection-periods? output-parameters)
+                      (conj :projection-periods))]
     (fs/mkdir output-directory)
     (fs/mkdir log-directory)
     (when (:output-file-inputs? output-parameters)
@@ -180,6 +183,11 @@
              (write/episodes-table t0 project-to)
              (write/write-csv! projection-episodes-output))
         (a/>!! result-chan :projection-episodes)))
+    (when (:output-projection-periods? output-parameters)
+      (a/thread
+        (->> (projection/project-n projection-mult)
+             (write/write-edn! projection-periods-output))
+        (a/>!! result-chan :projection-periods)))
     (fs/delete joiner-rates-log-output) ;; We're appending, so make sure we have a blank slate
     (fs/delete joiner-scenario-log-output)
     (fs/delete joiner-interval-log-output)

--- a/src/cic/repl.clj
+++ b/src/cic/repl.clj
@@ -1,5 +1,7 @@
 (ns cic.repl
   (:require [clojure.core.async :as a]
+            ;; Required for tagged literals in edn output
+            [clj-time.coerce :as c]
             [cic.episodes :as episodes]
             [cic.io.read :as read]
             [cic.io.write :as write]


### PR DESCRIPTION
The episodes CSV is a challenge to read and write. If we're passing between Clojure modules, why not use EDN?